### PR TITLE
CT-218 Form 데이터 Validation 작업

### DIFF
--- a/src/app/(admin)/_components/AdminSignUpFormContainer.tsx
+++ b/src/app/(admin)/_components/AdminSignUpFormContainer.tsx
@@ -15,26 +15,30 @@ export default function AdminSignUpFormContainer() {
   const {
     register,
     handleSubmit,
-    setError,
-    getValues,
+    watch,
     formState: { errors },
   } = useForm<SignUpForm>({ mode: "onChange" });
   const onValid = (data: SignUpForm) => {
-    if (data.password !== data.verify) {
-    } else {
-      // API 호출 구현 필요
-      const submitForm = { email: data.email, password: data.password };
-      api
-        .post("/admin-service/auth/signup", submitForm)
-        .then((res) => {
-          console.log(res);
-          setIsDone((prev) => !prev);
-        })
-        .catch((err) => console.error(err));
-    }
+    const submitForm = { email: data.email, password: data.password };
+    api
+      .post("/admin-service/auth/signup", submitForm)
+      .then((res) => {
+        console.log(res);
+        setIsDone((prev) => !prev);
+      })
+      .catch((err) => console.error(err));
   };
 
   const [isDone, setIsDone] = useState(false);
+
+  const checkEmailExists = async (email: string) => {
+    const { data: isEmailExists } = await api.post(
+      "/admin-service/auth/email",
+      {},
+      { params: { email } }
+    );
+    return isEmailExists ? "이미 가입된 이메일이에요" : undefined;
+  };
 
   return (
     <>
@@ -42,31 +46,69 @@ export default function AdminSignUpFormContainer() {
         <SignInTitle title="관리자 회원가입" />
         <form
           onSubmit={handleSubmit(onValid)}
-          className="flex flex-col w-full gap-8"
+          className="flex flex-col w-full gap-10"
         >
           {/* 아이디 비밀번호 입력 */}
-          <div className="flex flex-col gap-6">
-            <input
-              {...register("email", { required: true })}
-              className="sign-in-input"
-              placeholder="이메일"
-              autoComplete="off"
-              type="text"
-            />
-            <input
-              {...register("password", { required: true })}
-              className="sign-in-input"
-              placeholder="비밀번호"
-              autoComplete="off"
-              type="password"
-            />
-            <input
-              {...register("verify", { required: true })}
-              className="sign-in-input"
-              placeholder="비밀번호 확인"
-              autoComplete="off"
-              type="password"
-            />
+          <div className="flex flex-col gap-10">
+            <div className="relative">
+              <input
+                {...register("email", {
+                  required: "이메일을 입력해주세요",
+                  pattern: {
+                    value: /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/i,
+                    message: "이메일이 형식에 맞지 않습니다",
+                  },
+                  validate: async (email) => await checkEmailExists(email),
+                })}
+                className={`sign-in-input ${errors.email && "!border-red"}`}
+                placeholder="이메일"
+                autoComplete="off"
+                type="text"
+              />
+              {errors.email && (
+                <span className="form-error-text">{errors.email.message}</span>
+              )}
+            </div>
+            <div className="relative">
+              <input
+                {...register("password", {
+                  required: "비밀번호를 입력해주세요",
+                  pattern: {
+                    value:
+                      /^[A-Za-z\d!#$%^&*()_+={}\[\]|\\:;\"'<>,.?/~`-]{8,16}$/,
+                    message:
+                      "8 ~ 16자 사이의 영문, 숫자, 특수문자로 입력해주세요",
+                  },
+                })}
+                className={`sign-in-input ${errors.password && "!border-red"}`}
+                placeholder="비밀번호"
+                autoComplete="off"
+                type="password"
+              />
+              {errors.password && (
+                <span className="form-error-text">
+                  {errors.password.message}
+                </span>
+              )}
+            </div>
+            <div className="relative">
+              <input
+                {...register("verify", {
+                  required: "비밀번호를 다시 입력해주세요",
+                  validate: (value) =>
+                    watch("password") !== value
+                      ? "비밀번호가 일치하지 않아요"
+                      : undefined,
+                })}
+                className={`sign-in-input ${errors.verify && "!border-red"}`}
+                placeholder="비밀번호 확인"
+                autoComplete="off"
+                type="password"
+              />
+              {errors.verify && (
+                <span className="form-error-text">{errors.verify.message}</span>
+              )}
+            </div>
           </div>
           {/* 로그인 실패 시의 경고 메세지 */}
           {/* 로그인 / 회원가입 */}

--- a/src/app/(coding-test)/coding-test/[id]/page.tsx
+++ b/src/app/(coding-test)/coding-test/[id]/page.tsx
@@ -12,7 +12,6 @@ import { useEffect } from "react";
 import ChattingPanel from "../../_components/ChattingPanel";
 import LoadingSpinner from "@/app/_components/LoadingSpinner";
 import { PROGRAMMING_LANGUAGES } from "@/app/_constants/constants";
-import { handleWindowResize } from "@/app/utils";
 import { useCheckToken } from "@/app/_hooks/useCheckToken";
 
 export default function CodingTestPage() {
@@ -31,7 +30,6 @@ export default function CodingTestPage() {
   }, []);
 
   const { windowSize } = useWindowSizeStore();
-  handleWindowResize();
 
   return (
     <>

--- a/src/app/(home)/_components/MainBanner.tsx
+++ b/src/app/(home)/_components/MainBanner.tsx
@@ -4,7 +4,6 @@ import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 import { useRouter } from "next/navigation";
 import { useWindowSizeStore } from "@/app/stores";
-import { handleWindowResize } from "@/app/utils";
 import { BANNER_IMG_LIST } from "../_constants/constants";
 
 export default function MainBanner() {
@@ -51,7 +50,6 @@ export default function MainBanner() {
 
   // 화면 크기 변경 시 state 변경
   const { windowSize } = useWindowSizeStore();
-  handleWindowResize();
 
   // 배너 자동 전환 (다른 탭으로 이동 등 웹 페이지에서 벗어날 경우 애니메이션 비활성화)
   useEffect(() => {

--- a/src/app/(sign-in)/_components/SignUpFormContainer.tsx
+++ b/src/app/(sign-in)/_components/SignUpFormContainer.tsx
@@ -14,13 +14,14 @@ export default function SignUpFormContainer() {
     register,
     handleSubmit,
     setValue,
-    watch,
+    getValues,
     formState: { errors },
     setError,
     clearErrors,
   } = useForm<SignUpForm>({
     defaultValues: { useSocialProfile: false },
     mode: "onBlur",
+    reValidateMode: "onBlur",
   });
 
   // 회원가입 중에 토큰 임시 저장 및 localStorage에서의 토큰 삭제
@@ -39,6 +40,7 @@ export default function SignUpFormContainer() {
 
   // 닉네임 중복 검사 validation
   const checkNickNameExists = async (nickname: string) => {
+    console.log("checked");
     const { data: isNickNameExists } = await api.post(
       "/user-service/auth/nickname",
       {},
@@ -130,22 +132,26 @@ export default function SignUpFormContainer() {
       <div className="flex flex-col gap-2 relative">
         <span className="text-sm text-black">프로필 사진 선택</span>
         <ProfileImgSelection
-          seletedImg={watch("basicProfileUrl")}
+          seletedImg={getValues("basicProfileUrl")}
           onSelectionClick={(selected) => {
             setValue("basicProfileUrl", selected);
-            clearErrors("basicProfileUrl");
+            if (errors.basicProfileUrl) {
+              clearErrors("basicProfileUrl");
+            }
           }}
-          isDisabled={watch("useSocialProfile")}
+          isDisabled={getValues("useSocialProfile")}
           isError={errors.basicProfileUrl !== undefined}
         />
         <div>
           <SmCheckBoxBtn
-            isActive={watch("useSocialProfile")}
+            isActive={getValues("useSocialProfile")}
             content="소셜 아이디 프로필 사진 사용"
             onClick={() => {
-              const currentValue = watch("useSocialProfile");
+              const currentValue = getValues("useSocialProfile");
               setValue("useSocialProfile", !currentValue);
-              clearErrors("basicProfileUrl");
+              if (errors.basicProfileUrl) {
+                clearErrors("basicProfileUrl");
+              }
             }}
           />
         </div>

--- a/src/app/(sign-in)/_components/SignUpFormContainer.tsx
+++ b/src/app/(sign-in)/_components/SignUpFormContainer.tsx
@@ -40,7 +40,6 @@ export default function SignUpFormContainer() {
 
   // 닉네임 중복 검사 validation
   const checkNickNameExists = async (nickname: string) => {
-    console.log("checked");
     const { data: isNickNameExists } = await api.post(
       "/user-service/auth/nickname",
       {},
@@ -101,9 +100,7 @@ export default function SignUpFormContainer() {
           autoComplete="off"
         />
         {errors.nickName && (
-          <span className="absolute top-[calc(100%+4px)] left-0 whitespace-nowrap text-xs font-bold text-red">
-            {errors.nickName.message}
-          </span>
+          <span className="form-error-text">{errors.nickName.message}</span>
         )}
       </div>
       {/* 언어 선택 */}
@@ -122,7 +119,7 @@ export default function SignUpFormContainer() {
             isError={errors.codeLanguage !== undefined}
           />
           {errors.codeLanguage && (
-            <span className="absolute top-[calc(100%+4px)] left-0 whitespace-nowrap text-xs font-bold text-red">
+            <span className="form-error-text">
               {errors.codeLanguage.message}
             </span>
           )}
@@ -156,7 +153,7 @@ export default function SignUpFormContainer() {
           />
         </div>
         {errors.basicProfileUrl && (
-          <span className="absolute top-[calc(100%+4px)] left-0 whitespace-nowrap text-xs font-bold text-red">
+          <span className="form-error-text">
             {errors.basicProfileUrl.message}
           </span>
         )}

--- a/src/app/(sign-in)/_components/SignUpFormContainer.tsx
+++ b/src/app/(sign-in)/_components/SignUpFormContainer.tsx
@@ -6,13 +6,23 @@ import { useForm } from "react-hook-form";
 import { useRouter } from "next/navigation";
 import api from "@/app/_api/config";
 import { useEffect, useState } from "react";
-import { SmCheckBoxIcon } from "@/app/_components/Icons";
 import SmCheckBoxBtn from "@/app/_components/SmCheckBoxBtn";
 
 export default function SignUpFormContainer() {
   const router = useRouter();
-  const { register, handleSubmit, setValue, watch } = useForm<SignUpForm>({
+  const {
+    register,
+    handleSubmit,
+    getValues,
+    setValue,
+    watch,
+    formState: { errors },
+    setError,
+    clearErrors,
+    setFocus,
+  } = useForm<SignUpForm>({
     defaultValues: { useSocialProfile: false },
+    mode: "onBlur",
   });
 
   // 회원가입 중에 토큰 임시 저장 및 localStorage에서의 토큰 삭제
@@ -29,8 +39,47 @@ export default function SignUpFormContainer() {
 
   const [language, setLanguage] = useState("");
 
+  // 닉네임 validation
+  const onNickNameBlur = async () => {
+    const currentNickName = getValues("nickName");
+    if (currentNickName !== "") {
+      const { data: isDuplicated } = await api.post(
+        "/user-service/auth/nickname",
+        {},
+        { params: { nickname: currentNickName } }
+      );
+      if (isDuplicated) {
+        setError("nickName", {
+          type: "custom",
+          message: "중복된 닉네임이에요",
+        });
+      } else {
+        clearErrors("nickName");
+      }
+    } else {
+      setError("nickName", {
+        type: "custom",
+        message: "닉네임을 입력해주세요",
+      });
+    }
+  };
+
   const onValid = async (data: SignUpForm) => {
-    // 데이터 post 및 validation 필요
+    // data validation
+    if (!data.codeLanguage) {
+      setError("codeLanguage", {
+        type: "custom",
+        message: "언어를 선택해주세요",
+      });
+      return;
+    }
+    if (!data.basicProfileUrl || !data.useSocialProfile) {
+      setError("basicProfileUrl", {
+        type: "custom",
+        message: "프로필 사진을 선택해주세요",
+      });
+      return;
+    }
 
     try {
       const {
@@ -46,31 +95,52 @@ export default function SignUpFormContainer() {
       console.error(err);
     }
   };
+  console.log(errors.nickName, errors.nickName?.message);
 
   return (
-    <form onSubmit={handleSubmit(onValid)} className="flex flex-col gap-8">
+    <form onSubmit={handleSubmit(onValid)} className="flex flex-col gap-10">
       {/* 닉네임 입력 */}
-      <input
-        {...register("nickName", { required: true })}
-        className="sign-in-input"
-        placeholder="닉네임"
-        autoComplete="off"
-      />
+      <div className="relative flex flex-col gap-2">
+        <span className="text-sm text-black">닉네임</span>
+        <input
+          {...register("nickName", {
+            required: { value: true, message: "닉네임을 입력해주세요" },
+          })}
+          className={`sign-in-input ${errors.nickName && "!border-red"}`}
+          placeholder="닉네임"
+          autoComplete="off"
+          onBlur={onNickNameBlur}
+        />
+        {errors.nickName && (
+          <span className="absolute top-[calc(100%+4px)] left-0 whitespace-nowrap text-xs font-bold text-red">
+            {errors.nickName.message}
+          </span>
+        )}
+      </div>
       {/* 언어 선택 */}
       <div className="flex flex-col gap-2">
         <span className="text-sm text-black">기본 프로그래밍 언어</span>
-        <DropDown
-          selection={language}
-          placeholder="언어를 선택해주세요"
-          list={PROGRAMMING_LANGUAGES}
-          onSelectionClick={(selected) => {
-            setValue("codeLanguage", selected.selection);
-            setLanguage(selected.content);
-          }}
-        />
+        <div className="relative">
+          <DropDown
+            selection={language}
+            placeholder="언어를 선택해주세요"
+            list={PROGRAMMING_LANGUAGES}
+            onSelectionClick={(selected) => {
+              setValue("codeLanguage", selected.selection);
+              setLanguage(selected.content);
+              clearErrors("codeLanguage");
+            }}
+            isError={errors.codeLanguage !== undefined}
+          />
+          {errors.codeLanguage && (
+            <span className="absolute top-[calc(100%+4px)] left-0 whitespace-nowrap text-xs font-bold text-red">
+              {errors.codeLanguage.message}
+            </span>
+          )}
+        </div>
       </div>
       {/* 프로필 사진 선택 */}
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-2 relative">
         <span className="text-sm text-black">프로필 사진 선택</span>
         <ProfileImgSelection
           seletedImg={watch("basicProfileUrl")}
@@ -78,6 +148,7 @@ export default function SignUpFormContainer() {
             setValue("basicProfileUrl", selected);
           }}
           isDisabled={watch("useSocialProfile")}
+          isError={errors.basicProfileUrl !== undefined}
         />
         <div>
           <SmCheckBoxBtn
@@ -89,6 +160,11 @@ export default function SignUpFormContainer() {
             }}
           />
         </div>
+        {errors.basicProfileUrl && (
+          <span className="absolute top-[calc(100%+4px)] left-0 whitespace-nowrap text-xs font-bold text-red">
+            {errors.basicProfileUrl.message}
+          </span>
+        )}
       </div>
       <button type="submit" className="btn-primary">
         완료

--- a/src/app/_components/Dropdown.tsx
+++ b/src/app/_components/Dropdown.tsx
@@ -11,6 +11,7 @@ export default function DropDown({
   onSelectionClick,
   placeholder,
   showListUpward,
+  isError,
 }: DropDownProps) {
   const [isListOpen, setIsListOpen] = useState(false);
   const ref = useOutsideClick(
@@ -29,7 +30,7 @@ export default function DropDown({
           : "border-r border-border-2"
       } ${isListOpen && "z-10"} ${
         list?.length === 0 ? "bg-bg-1" : "bg-white cursor-pointer"
-      }`}
+      } ${isError && "!border-red"}`}
     >
       <div className={`${isListOpen && "rotate-180"}`}>
         <ShowMoreIcon />

--- a/src/app/_components/ProfileImgSelection.tsx
+++ b/src/app/_components/ProfileImgSelection.tsx
@@ -7,11 +7,16 @@ export default function ProfileImgSelection({
   seletedImg,
   onSelectionClick,
   isDisabled,
+  isError,
 }: ProfileImgSelectionProps) {
   const [profileImg, setProfileImg] = useState(seletedImg);
 
   return (
-    <div className="relative w-full px-4 py-6 grid grid-cols-3 place-items-center gap-4 border border-border-2 rounded-lg overflow-hidden">
+    <div
+      className={`relative w-full px-4 py-6 grid grid-cols-3 place-items-center gap-4 border border-border-2 rounded-lg overflow-hidden  ${
+        isError && "!border-red"
+      }`}
+    >
       {isDisabled && (
         <div className="absolute w-full h-full bg-black opacity-20" />
       )}

--- a/src/app/_components/TopBar/TopBar.tsx
+++ b/src/app/_components/TopBar/TopBar.tsx
@@ -17,6 +17,7 @@ import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { PushesResponse, UserInfo } from "@/app/_interfaces/interfaces";
 import { useInView } from "react-intersection-observer";
 import LoadingAnimation from "../LoadingAnimation";
+import { handleWindowResize } from "@/app/utils";
 
 export default function TopBar() {
   const pathname = usePathname();
@@ -80,6 +81,7 @@ export default function TopBar() {
   });
 
   const { windowSize } = useWindowSizeStore();
+  handleWindowResize();
 
   // 사용자 정보 API 호출
   const fetchUserInfo = async () => {
@@ -149,6 +151,16 @@ export default function TopBar() {
       fetchNextPage();
     }
   }, [inView]);
+
+  const maxWidth = pathname.startsWith("/coding-test")
+    ? 0
+    : pathname.startsWith("/recent-post") || pathname.startsWith("/code-post")
+    ? 1000
+    : 1200;
+  const pushLocation = `calc(8px + ${Math.max(
+    (windowSize - maxWidth) / 2,
+    0
+  )}px)`;
 
   return (
     <div className="fixed w-full h-16 z-50">
@@ -242,7 +254,7 @@ export default function TopBar() {
         <div
           ref={noticePopupRef}
           style={{
-            right: `calc(8px + ${Math.max((windowSize - 1200) / 2, 0)}px)`,
+            right: pushLocation,
           }}
           className="absolute bg-white top-[calc(100%+8px)] w-[396px] h-[300px] flex flex-col items-center rounded-lg shadow-1 divide-y divide-border-1 overflow-y-auto"
         >

--- a/src/app/_components/TopBar/TopBar.tsx
+++ b/src/app/_components/TopBar/TopBar.tsx
@@ -80,9 +80,6 @@ export default function TopBar() {
     if (isOpen.menu) onIconClick("menu", false);
   });
 
-  const { windowSize } = useWindowSizeStore();
-  handleWindowResize();
-
   // 사용자 정보 API 호출
   const fetchUserInfo = async () => {
     if (accessToken) {
@@ -152,12 +149,14 @@ export default function TopBar() {
     }
   }, [inView]);
 
+  const { windowSize } = useWindowSizeStore();
+  handleWindowResize();
   const maxWidth = pathname.startsWith("/coding-test")
     ? 0
     : pathname.startsWith("/recent-post") || pathname.startsWith("/code-post")
     ? 1000
     : 1200;
-  const pushLocation = `calc(8px + ${Math.max(
+  const popUpLocation = `calc(8px + ${Math.max(
     (windowSize - maxWidth) / 2,
     0
   )}px)`;
@@ -254,7 +253,7 @@ export default function TopBar() {
         <div
           ref={noticePopupRef}
           style={{
-            right: pushLocation,
+            right: popUpLocation,
           }}
           className="absolute bg-white top-[calc(100%+8px)] w-[396px] h-[300px] flex flex-col items-center rounded-lg shadow-1 divide-y divide-border-1 overflow-y-auto"
         >
@@ -283,7 +282,7 @@ export default function TopBar() {
         <div
           ref={profilePopupRef}
           style={{
-            right: `calc(8px + ${Math.max((windowSize - 1200) / 2, 0)}px)`,
+            right: popUpLocation,
           }}
           className="absolute bg-white top-[calc(100%+8px)] w-[160px] flex flex-col rounded-lg shadow-1 divide-y divide-border-1"
         >

--- a/src/app/_interfaces/interfaces.ts
+++ b/src/app/_interfaces/interfaces.ts
@@ -35,6 +35,7 @@ export interface DropDownProps {
   placeholder?: string;
   disabled?: boolean;
   showListUpward?: boolean;
+  isError?: boolean;
 }
 
 export interface ParamDropDownProps {
@@ -132,6 +133,7 @@ export interface ProfileImgSelectionProps {
   seletedImg: string;
   onSelectionClick: (seleted: string) => void;
   isDisabled?: boolean;
+  isError?: boolean;
 }
 
 export interface EditBtnProps {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -347,4 +347,9 @@ textarea {
   .code-card-value {
     @apply text-xs text-body flex gap-1 max-sm:flex-col items-center;
   }
+
+  /* Form 작성 오류 시 텍스트 */
+  .form-error-text {
+    @apply absolute top-[calc(100%+4px)] left-0 whitespace-nowrap text-xs font-bold text-red;
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 티켓 넘버

> CT-218

## 📝작업 내용

> 회원가입 시의 Validation을 구현하였습니다.
> 관리자 로그인 시의 Validation을 구현하였습니다.
> 관리자 회원가입 시의 Validation을 구현하였습니다.


> 수동으로 onBlur를 사용하여 Validation을 처리하던 기존 방식을, react-hook-form의 register 내에서 처리하는 방식으로 변경하여 Validation을 간소화하였습니다.
> TopBar 팝업(알림, 내 정보)의 위치가 메인 페이지에서만 적용되는 오류를 수정하였습니다. handleWindowResize 함수를 TopBar에서 사용하여 팝업의 위치를 조정하였고, 그 외 페이지 내에서 호출되던 handleWindowResize를 제거하였습니다.

> useForm의 mode를 onBlur로 설정해두었음에도 불구하고 Form이 Submit된 이후에는 input의 Validation을 onBlur 시에 수행하는 것이 아닌 onChange 시에 수행하는 것을 확인하였습니다. 이는 Submit 이후의 mode를 결정하는 reValidateMode의 Default 값이 onChange로 설정되어 있었기 때문인 것을 알게 되었습니다. 기획 상의 의도는 에러가 발생한 뒤에도 Validation은 onBlur 시에 작동하는 것이었기 때문에 reValidateMode를 onBlur로 설정하여 문제를 해결하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)